### PR TITLE
Remove alpn and tlsa params, make all priorities 1

### DIFF
--- a/draft.xml.in
+++ b/draft.xml.in
@@ -174,11 +174,9 @@ Example <tt>&lt;deleg:deleg&gt;</tt> element:
 
 <sourcecode><![CDATA[
 <deleg:deleg
-  priority="0"
+  priority="1"
   target="ns1.example.com">
   <deleg:params
-    alpn="dot"
-    tlsa="2 0 1 ABC..."
     ipv4hint="192.0.2.1"
     ipv6hint="2001:DB8::1"/>
 </deleg:deleg>

--- a/examples/domain-create-command.xml
+++ b/examples/domain-create-command.xml
@@ -14,17 +14,13 @@
     <extension>
       <deleg:create
         xmlns:deleg="urn:ietf:params:xml:ns:epp:deleg-0.01">
-        <deleg:deleg priority="0" target="ns1.example.com">
+        <deleg:deleg priority="1" target="ns1.example.com">
           <deleg:params
-            alpn="dot"
-            tlsa="2 0 1 ABC..."
             ipv4hint="192.0.2.1"
             ipv6hint="2001:DB8::1"/>
         </deleg:deleg>
         <deleg:deleg priority="1" target="ns2.example.net">
           <deleg:params
-            alpn="dot"
-            tlsa="2 0 1 XYZ..."
             ipv4hint="192.0.2.2"
             ipv6hint="2001:DB8::2"/>
         </deleg:deleg>

--- a/examples/domain-info-response.xml
+++ b/examples/domain-info-response.xml
@@ -19,17 +19,13 @@
     <extension>
       <deleg:infData
         xmlns:deleg="urn:ietf:params:xml:ns:epp:deleg-0.01">
-        <deleg:deleg priority="0" target="ns1.example.com">
+        <deleg:deleg priority="1" target="ns1.example.com">
           <deleg:params
-            alpn="dot"
-            tlsa="2 0 1 ABC..."
             ipv4hint="192.0.2.1"
             ipv6hint="2001:DB8::1"/>
         </deleg:deleg>
         <deleg:deleg priority="1" target="ns2.example.net">
           <deleg:params
-            alpn="dot"
-            tlsa="2 0 1 XYZ..."
             ipv4hint="192.0.2.2"
             ipv6hint="2001:DB8::2"/>
         </deleg:deleg>

--- a/examples/domain-update-add-only-command.xml
+++ b/examples/domain-update-add-only-command.xml
@@ -12,8 +12,6 @@
         <deleg:add>
           <deleg:deleg priority="1" target="ns3.example.org">
             <deleg:params
-              alpn="dot"
-              tlsa="2 0 1 XYZ..."
               ipv4hint="192.0.2.3"
               ipv6hint="2001:DB8::3"/>
           </deleg:deleg>

--- a/examples/domain-update-command.xml
+++ b/examples/domain-update-command.xml
@@ -12,17 +12,13 @@
         <deleg:add>
           <deleg:deleg priority="1" target="ns3.example.org">
             <deleg:params
-              alpn="dot"
-              tlsa="2 0 1 XYZ..."
               ipv4hint="192.0.2.3"
               ipv6hint="2001:DB8::3"/>
           </deleg:deleg>
         </deleg:add>
         <deleg:rem>
-          <deleg:deleg priority="0" target="ns1.example.com">
+          <deleg:deleg priority="1" target="ns1.example.com">
             <deleg:params
-              alpn="dot"
-              tlsa="2 0 1 ABC..."
               ipv4hint="192.0.2.1"
               ipv6hint="2001:DB8::1"/>
           </deleg:deleg>

--- a/examples/domain-update-rem-only-command.xml
+++ b/examples/domain-update-rem-only-command.xml
@@ -12,8 +12,6 @@
         <deleg:rem>
           <deleg:deleg priority="1" target="ns3.example.org">
             <deleg:params
-              alpn="dot"
-              tlsa="2 0 1 XYZ..."
               ipv4hint="192.0.2.3"
               ipv6hint="2001:DB8::3"/>
           </deleg:deleg>


### PR DESCRIPTION
We still should probably have an example with priority 0, but note in the text that such a record MUST NOT have any params